### PR TITLE
Properly escape HTML

### DIFF
--- a/lib/coco/formatter/html_formatter.rb
+++ b/lib/coco/formatter/html_formatter.rb
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 
+require 'cgi'
 require 'erb'
 
 module Coco
@@ -28,7 +29,7 @@ module Coco
       source = File.readlines filename
       lines = []
       source.each_with_index do |line, index|
-        lines << [index+1, line.chomp.gsub(/</, '&lt;').gsub(/>/, '&gt;'), coverage[index]]
+        lines << [index+1, CGI.escapeHTML(line.chomp), coverage[index]]
       end
       @context = Context.new filename, lines
       @formatted_output_files[filename] = @template.result(@context.get_binding)


### PR DESCRIPTION
It is much better to let the stdlib CGI module do the HTML escaping instead of redoing it. Also, the previous code did not properly escape `&` and other chars.
