### PR TITLE
Streamline LOAD_PATH and COCO_PATH

### DIFF
--- a/lib/coco.rb
+++ b/lib/coco.rb
@@ -1,12 +1,14 @@
 # -*- encoding: utf-8 -*-
 
 $COCO_PATH = File.expand_path(File.dirname(__FILE__) + '/..')
+
 require 'coco/formatter'
 require 'coco/cover'
 require 'coco/writer'
 require 'coco/helpers'
 require 'coco/configuration'
 require 'coco/lister'
+
 require 'coverage'
 
 module Coco


### PR DESCRIPTION
There is no need to modify LOAD_PATH. MRI, bundler and rvm all work fine without it.

Also, the generation of COCO_PATH can and has been simplified (maybe the template files should be moved somewhere under the `lib/` directory).
