### PR TITLE
Explicit support for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
   - "1.9.3"
   - "2.0.0"
   - "2.1"
+  - jruby-19mode
 before_install: gem install bundler

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'rake/dsl_definition'
 require 'rake'
 require 'rspec/core/rake_task'

--- a/coco.gemspec
+++ b/coco.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'rake'
 
 Gem::Specification.new do |s|

--- a/lib/coco.rb
+++ b/lib/coco.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 $COCO_PATH = File.expand_path(File.dirname(__FILE__) + '/..')
 
 require 'coco/formatter'

--- a/lib/coco/configuration.rb
+++ b/lib/coco/configuration.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'yaml'
 
 module Coco

--- a/lib/coco/cover.rb
+++ b/lib/coco/cover.rb
@@ -1,4 +1,2 @@
-# -*- encoding: utf-8 -*-
-
 require 'coco/cover/coverage_stat'
 require 'coco/cover/coverage_result'

--- a/lib/coco/cover/coverage_result.rb
+++ b/lib/coco/cover/coverage_result.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Compute results of interest from the big results information (from

--- a/lib/coco/cover/coverage_stat.rb
+++ b/lib/coco/cover/coverage_stat.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Public: Give statistics about an array of lines hit.

--- a/lib/coco/formatter/colored_string.rb
+++ b/lib/coco/formatter/colored_string.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Public: Build String with ANSI colorization.

--- a/lib/coco/formatter/console_formatter.rb
+++ b/lib/coco/formatter/console_formatter.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # I format coverages information for console output.

--- a/lib/coco/formatter/context.rb
+++ b/lib/coco/formatter/context.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Contextual information for ERB template, representing each covered files.

--- a/lib/coco/formatter/formatter.rb
+++ b/lib/coco/formatter/formatter.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
   
   # My childs will format coverages information.

--- a/lib/coco/formatter/html_formatter.rb
+++ b/lib/coco/formatter/html_formatter.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'cgi'
 require 'erb'
 

--- a/lib/coco/formatter/html_index_formatter.rb
+++ b/lib/coco/formatter/html_index_formatter.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'erb'
 
 module Coco

--- a/lib/coco/formatter/template.rb
+++ b/lib/coco/formatter/template.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'erb'
 
 module Coco

--- a/lib/coco/helpers.rb
+++ b/lib/coco/helpers.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Public: Collection of application's helpers methods.

--- a/lib/coco/lister.rb
+++ b/lib/coco/lister.rb
@@ -1,4 +1,2 @@
-# -*- encoding: utf-8 -*-
-
 require 'coco/lister/source_lister'
 require 'coco/lister/uncovered_lister'

--- a/lib/coco/lister/source_lister.rb
+++ b/lib/coco/lister/source_lister.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # I retrieve the .rb files from a list of directories.

--- a/lib/coco/lister/uncovered_lister.rb
+++ b/lib/coco/lister/uncovered_lister.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # I retrieve the list of uncovered (0%) .rb files.

--- a/lib/coco/writer.rb
+++ b/lib/coco/writer.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'coco/writer/file_writer'
 require 'coco/writer/html_directory'
 require 'coco/writer/html_files_writer'

--- a/lib/coco/writer/file_writer.rb
+++ b/lib/coco/writer/file_writer.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
   
   # I write one file.

--- a/lib/coco/writer/html_directory.rb
+++ b/lib/coco/writer/html_directory.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Public: I prepare the coverage/ directory for html files.

--- a/lib/coco/writer/html_files_writer.rb
+++ b/lib/coco/writer/html_files_writer.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
 
   # Public: I populate the coverage/ directory with files, if any.

--- a/lib/coco/writer/html_index_writer.rb
+++ b/lib/coco/writer/html_index_writer.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Coco
   
   # Public: I write the index.html

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 require 'yaml'
 

--- a/spec/coverage_result_spec.rb
+++ b/spec/coverage_result_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 RAW_RESULT = {

--- a/spec/coverage_stat_spec.rb
+++ b/spec/coverage_stat_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 HITS = [nil, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/spec/formatters_spec.rb
+++ b/spec/formatters_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 describe ConsoleFormatter do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './lib/coco'
 require 'fileutils'
 include Coco

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 describe Helpers do

--- a/spec/html_writers_spec.rb
+++ b/spec/html_writers_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 describe HtmlDirectory do

--- a/spec/source_lister_spec.rb
+++ b/spec/source_lister_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 describe SourceLister do

--- a/spec/uncovered_lister_spec.rb
+++ b/spec/uncovered_lister_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require './spec/helper'
 
 SOURCE_FILES_1 = [


### PR DESCRIPTION
This PR adds JRuby to Travis-CI and removes encoding magic comments to make loading a bit faster on JRuby (and maybe other implementations).

Please merge this PR after the gemfile cleanups PR has been applied and `Gemfile.lock` removed.