### PR TITLE
No $COCO_PATH global

### DIFF
--- a/lib/coco.rb
+++ b/lib/coco.rb
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-$COCO_PATH = File.expand_path(File.dirname(__FILE__) + '/..')
-
 require 'coco/formatter'
 require 'coco/cover'
 require 'coco/writer'
@@ -12,6 +10,7 @@ require 'coco/lister'
 require 'coverage'
 
 module Coco
+	ROOT = File.expand_path(File.dirname(__FILE__) + '/..').freeze
 end
 
 Coverage.start

--- a/lib/coco/formatter/html_formatter.rb
+++ b/lib/coco/formatter/html_formatter.rb
@@ -13,7 +13,7 @@ module Coco
       super(raw_coverages, [])
       @formatted_output_files = {}
       @context = nil
-      @template = Template.open File.join($COCO_PATH,'template/file.erb')
+      @template = Template.open File.join(Coco::ROOT, 'template/file.erb')
     end
     
     def format

--- a/lib/coco/formatter/html_index_formatter.rb
+++ b/lib/coco/formatter/html_index_formatter.rb
@@ -10,7 +10,7 @@ module Coco
     def initialize(raw_coverages, uncovered)
       super(raw_coverages, uncovered)
       @context = nil
-      @template = Template.open File.join($COCO_PATH,'template/index.erb')
+      @template = Template.open File.join(Coco::ROOT, 'template/index.erb')
       @lines = []
       build_lines_for_context
     end

--- a/lib/coco/helpers.rb
+++ b/lib/coco/helpers.rb
@@ -30,7 +30,7 @@ module Coco
       # Returns String.
       def index_title
         project_name = File.basename(Dir.pwd)
-        version = File.read(File.join($COCO_PATH, 'VERSION')).strip
+        version = File.read(File.join(Coco::ROOT, 'VERSION')).strip
         "#{project_name} - Code coverage (coco #{version})"
       end
 

--- a/lib/coco/writer/html_directory.rb
+++ b/lib/coco/writer/html_directory.rb
@@ -8,9 +8,9 @@ module Coco
 
     # Public: Initialize a new HtmlDirectory object.
     def initialize
-      css = File.join($COCO_PATH, 'template/css')
+      css = File.join(Coco::ROOT, 'template/css')
       @css_files = Dir.glob(css + '/*')
-      img = File.join($COCO_PATH, 'template/img')
+      img = File.join(Coco::ROOT, 'template/img')
       @img_files = Dir.glob(img + '/*')
     end
 

--- a/spec/formatters_spec.rb
+++ b/spec/formatters_spec.rb
@@ -78,7 +78,7 @@ describe HtmlFormatter do
 
   # Bug 13
   it "should produce html entities for < and >" do
-    file = File.join($COCO_PATH, 'spec/project/html_entities.rb')
+    file = File.join(Coco::ROOT, 'spec/project/html_entities.rb')
     coverage = {file => [1, 1, 0, nil, 1, 1, nil, nil]}
     formatter = HtmlFormatter.new coverage
     result = formatter.format[file]

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -7,8 +7,8 @@ include Coco
 COVERAGE_100 = {'the/filename/100' => [nil, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
 COVERAGE_90 = {'the/filename/90' => [nil, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
 COVERAGE_80 = {'the/filename/80' => [nil, 0, 0, 2, 3, 4, 5, 6, 7, 8, 9]}
-COVERAGE_70 = {File.join($COCO_PATH, 'spec/project/ten_lines.rb') => [0, 0, 0, 3, 4, 5, 6, 7, 8, 9]}
-COVERAGE_30 = {File.join($COCO_PATH, 'spec/project/six_lines.rb') => [0, 0, 0, 4, 5, 6]}
+COVERAGE_70 = {File.join(Coco::ROOT, 'spec/project/ten_lines.rb') => [0, 0, 0, 3, 4, 5, 6, 7, 8, 9]}
+COVERAGE_30 = {File.join(Coco::ROOT, 'spec/project/six_lines.rb') => [0, 0, 0, 4, 5, 6]}
 COVERAGE_30_70 = COVERAGE_30.merge(COVERAGE_70)
 COVERAGE_100_90_80 = COVERAGE_80.merge(COVERAGE_90).merge(COVERAGE_100)
 

--- a/spec/uncovered_lister_spec.rb
+++ b/spec/uncovered_lister_spec.rb
@@ -3,10 +3,10 @@
 require './spec/helper'
 
 SOURCE_FILES_1 = [
-  File.join($COCO_PATH, 'spec/project/ten_lines.rb'),
-  File.join($COCO_PATH, 'spec/project/six_lines.rb'),
-  File.join($COCO_PATH, 'spec/project/uncovered1.rb'),
-  File.join($COCO_PATH, 'spec/project/uncovered2.rb')
+  File.join(Coco::ROOT, 'spec/project/ten_lines.rb'),
+  File.join(Coco::ROOT, 'spec/project/six_lines.rb'),
+  File.join(Coco::ROOT, 'spec/project/uncovered1.rb'),
+  File.join(Coco::ROOT, 'spec/project/uncovered2.rb')
 ]
 
 describe UncoveredLister do
@@ -14,7 +14,7 @@ describe UncoveredLister do
   it "must give the list of uncovered files" do
     uncov = UncoveredLister.new(SOURCE_FILES_1, COVERAGE_30_70)
     list = uncov.list
-    list.include?(File.join($COCO_PATH, 'spec/project/uncovered1.rb')).should == true
-    list.include?(File.join($COCO_PATH, 'spec/project/uncovered2.rb')).should == true
+    list.include?(File.join(Coco::ROOT, 'spec/project/uncovered1.rb')).should == true
+    list.include?(File.join(Coco::ROOT, 'spec/project/uncovered2.rb')).should == true
   end
 end


### PR DESCRIPTION
This PR removes the `$COCO_PATH` variable in favour of the constant `Coco::ROOT`.

More information in the commit message.
