### PR TITLE
Add missing quotes in Gemfile instruction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ Install
 
 In your Gemfile:
 
-    gem coco
+    gem 'coco'
 
 Or directly:
 


### PR DESCRIPTION
The gem argument was missing quotes which can leads some people to don't understand why copy / pasting the line breaks their Gemfile.