### PR TITLE
Replace tabs with spaces. Without this ruby complains when running test tasks with warnings enabled due to 'warning: mismatched indentations at 'end'

### DIFF
--- a/lib/coco/formatter/context.rb
+++ b/lib/coco/formatter/context.rb
@@ -8,18 +8,18 @@ module Coco
     #
     # filename - A String name of the source file.
     # lines    - An Array of lines.
-		def initialize(filename, lines)
-			@filename = filename
+    def initialize(filename, lines)
+      @filename = filename
       @lines = lines
-		end
-		
+    end
+
     # Public: Get the object's binding.
     #
     # Returns Binding.
-		def get_binding
-			binding
-		end
-	end
+    def get_binding
+      binding
+    end
+  end
 
   # Contextual information for ERB template, representing index.html.
   class IndexContext
@@ -38,18 +38,18 @@ module Coco
     # uncovered - Array of String filenames. The filenames are already
     #             formatted, ready to be display in an HTML file.
     #
-		def initialize(title, covered, uncovered)
-			@title = title
+    def initialize(title, covered, uncovered)
+      @title = title
       @covered = covered
       @uncovered = uncovered
-		end
-		
+    end
+
     # Public: Get the object's binding.
     #
     # Returns Binding.
-		def get_binding
-			binding
-		end
-	end
+    def get_binding
+      binding
+    end
+  end
 
 end

--- a/lib/coco/formatter/template.rb
+++ b/lib/coco/formatter/template.rb
@@ -1,7 +1,7 @@
 require 'erb'
 
 module Coco
-  
+
   # From me, you can obtain ERB templates.
   class Template
     # filename - An String ERB template.
@@ -9,7 +9,7 @@ module Coco
     # Returns ERB.
     def self.open(filename)
       io = IO.readlines(filename, nil)
-			ERB.new(io[0], nil, '><')
+      ERB.new(io[0], nil, '><')
     end
   end
 


### PR DESCRIPTION
Fix #45 